### PR TITLE
Add Scope variable to OAuthCredential

### DIFF
--- a/AFOAuth2Client/AFOAuth2Client.h
+++ b/AFOAuth2Client/AFOAuth2Client.h
@@ -194,6 +194,11 @@
 @property (readonly, nonatomic) NSString *refreshToken;
 
 /**
+ The OAuth scope
+ */
+@property (readonly, nonatomic) NSString *scope;
+
+/**
  Whether the OAuth credentials are expired.
  */
 @property (readonly, nonatomic, assign, getter = isExpired) BOOL expired;
@@ -241,6 +246,17 @@
  */
 - (void)setRefreshToken:(NSString *)refreshToken
              expiration:(NSDate *)expiration;
+
+///----------------------------
+/// @name Setting Scope
+///----------------------------
+
+/**
+ Sets the scope parameter.
+
+ @param scope The scope of the OAuth token.
+ */
+- (void)setScope:(NSString *)scope;
 
 ///-----------------------------------------
 /// @name Storing and Retrieving Credentials

--- a/AFOAuth2Client/AFOAuth2Client.m
+++ b/AFOAuth2Client/AFOAuth2Client.m
@@ -210,7 +210,8 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifierDefault(NSSt
         }
         
         [credential setRefreshToken:refreshToken expiration:expireDate];
-        
+        [credential setScope:[responseObject valueForKey:@"scope"]];
+
         [self setAuthorizationHeaderWithCredential:credential];
         
         if (success) {
@@ -232,15 +233,16 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifierDefault(NSSt
 @property (readwrite, nonatomic) NSString *accessToken;
 @property (readwrite, nonatomic) NSString *tokenType;
 @property (readwrite, nonatomic) NSString *refreshToken;
+@property (readwrite, nonatomic) NSString *scope;
 @property (readwrite, nonatomic) NSDate *expiration;
 @property (readwrite, nonatomic) NSDictionary *authorizationResponse;
-
 @end
 
 @implementation AFOAuthCredential
 @synthesize accessToken = _accessToken;
 @synthesize tokenType = _tokenType;
 @synthesize refreshToken = _refreshToken;
+@synthesize scope = _scope;
 @synthesize expiration = _expiration;
 @synthesize authorizationResponse = _authorizationResponse;
 @dynamic expired;
@@ -283,6 +285,10 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifierDefault(NSSt
     
     self.refreshToken = refreshToken;
     self.expiration = expiration;
+}
+
+- (void)setScope:(NSString *)scope {
+    _scope = scope;
 }
 
 - (BOOL)isExpired {
@@ -394,6 +400,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifierDefault(NSSt
     self.tokenType = [decoder decodeObjectForKey:@"tokenType"];
     self.refreshToken = [decoder decodeObjectForKey:@"refreshToken"];
     self.expiration = [decoder decodeObjectForKey:@"expiration"];
+    self.scope = [decoder decodeObjectForKey:@"scope"];
     
     return self;
 }
@@ -403,6 +410,7 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifierDefault(NSSt
     [encoder encodeObject:self.tokenType forKey:@"tokenType"];
     [encoder encodeObject:self.refreshToken forKey:@"refreshToken"];
     [encoder encodeObject:self.expiration forKey:@"expiration"];
+    [encoder encodeObject:self.scope forKey:@"scope"];
 }
 
 @end


### PR DESCRIPTION
this commit adds the scope variable to the OAuthCredential so that we know what scope the token has.

This allows us to know whether or not we need to convert a guest authentication entity into a user authentication entity or not.